### PR TITLE
fix: Correct the name of the maintainer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Tras esto, correrán las pruebas y, si todo sale bien, se mergearán las ramas y
 
 ## Autores
 
-* **Ismael Aderdor** - *Trabajo inicial* - [PurpleBooth](https://github.com/iaderdor)
+* **Ismael Aderdor** - *Trabajo inicial* - [iaderdor](https://github.com/iaderdor)
 
 ## License
 


### PR DESCRIPTION
Please, when copying a template for a README from other people, try to
examine in detail all the text, just in case you left something that
should not be there.